### PR TITLE
Experiment: adapt RM3 expansion for sparse title queries

### DIFF
--- a/experiment_evaluations/codex/search-adaptive-rm3-sparse/trec_eval-20260323-113344.txt
+++ b/experiment_evaluations/codex/search-adaptive-rm3-sparse/trec_eval-20260323-113344.txt
@@ -1,0 +1,118 @@
+branch: codex/search-adaptive-rm3-sparse
+timestamp: 20260323-113344
+collection: /Users/caiau/school/wsj.xml
+topics: /Users/caiau/school/autoresearch/51-100.titles.txt
+qrels: /Users/caiau/school/autoresearch/51-100.qrels.txt
+
+JASSJR_SEMANTIC_MODE: openai
+JASSJR_OPENAI_RERANK_MODE: mono
+
+JASSJR_ABLATION_BM25_ONLY: /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse/ablation-runs/bm25-only.trec
+JASSJR_ABLATION_BM25_RM3_FUSION: /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse/ablation-runs/bm25-rm3-fusion.trec
+JASSJR_ABLATION_BM25_DENSE_FUSION: /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse/ablation-runs/bm25-dense-fusion.trec
+JASSJR_ABLATION_BM25_RM3_DENSE_FUSION: /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse/ablation-runs/bm25-rm3-dense-fusion.trec
+JASSJR_SEMANTIC_MODE: openai
+JASSJR_SEMANTIC_KEY_SOURCE: dotenv
+JASSJR_SEMANTIC_MODEL: text-embedding-3-small
+JASSJR_SEMANTIC_DIMENSIONS: 512
+JASSJR_SEMANTIC_DOC_WORDS: 220
+JASSJR_SEMANTIC_BATCH_SIZE: 64
+JASSJR_SEMANTIC_DOCUMENTS: 173252
+JASSJR_SEMANTIC_DOC_VECTOR_FILE: /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse/dense-docs.f32
+JASSJR_SEMANTIC_DOC_VECTOR_META: /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse/dense-docs.meta.json
+
+JASSJR_SEMANTIC_MODE: openai
+JASSJR_SEMANTIC_KEY_SOURCE: dotenv
+JASSJR_SEMANTIC_MODEL: text-embedding-3-small
+JASSJR_SEMANTIC_DIMENSIONS: 512
+JASSJR_SEMANTIC_DOC_WORDS: 220
+JASSJR_SEMANTIC_DOCUMENTS: 173252
+JASSJR_SEMANTIC_DOC_VECTOR_FILE: /Users/caiau/school/autoresearch/wsj-grid-search/codex/search-fusion-weight-grid/dense-docs.f32
+JASSJR_SEMANTIC_OUTPUT_DOCS: 1000
+JASSJR_SEMANTIC_PROMPT_TOKENS: 203
+JASSJR_SEMANTIC_TOTAL_TOKENS: 203
+
+JASSJR_FUSION_RRF_K: 60
+JASSJR_FUSION_OUTPUT_FILE: /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse/ablation-runs/bm25-rm3-fusion.trec
+JASSJR_FUSION_SOURCE_ORDER: bm25,rm3
+JASSJR_FUSION_SOURCE_BM25_PATH: /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse/pipeline-run.SP2rq0/results-bm25.trec
+JASSJR_FUSION_SOURCE_BM25_WEIGHT: 0.05
+JASSJR_FUSION_SOURCE_BM25_TOPK: 250
+JASSJR_FUSION_SOURCE_RM3_PATH: /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse/pipeline-run.SP2rq0/results-rm3.trec
+JASSJR_FUSION_SOURCE_RM3_WEIGHT: 0.55
+JASSJR_FUSION_SOURCE_RM3_TOPK: 250
+
+JASSJR_FUSION_RRF_K: 60
+JASSJR_FUSION_OUTPUT_FILE: /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse/ablation-runs/bm25-dense-fusion.trec
+JASSJR_FUSION_SOURCE_ORDER: bm25,dense
+JASSJR_FUSION_SOURCE_BM25_PATH: /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse/pipeline-run.SP2rq0/results-bm25.trec
+JASSJR_FUSION_SOURCE_BM25_WEIGHT: 0.05
+JASSJR_FUSION_SOURCE_BM25_TOPK: 250
+JASSJR_FUSION_SOURCE_DENSE_PATH: /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse/pipeline-run.SP2rq0/results-dense.trec
+JASSJR_FUSION_SOURCE_DENSE_WEIGHT: 0.4
+JASSJR_FUSION_SOURCE_DENSE_TOPK: 250
+
+JASSJR_FUSION_RRF_K: 60
+JASSJR_FUSION_OUTPUT_FILE: /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse/ablation-runs/bm25-rm3-dense-fusion.trec
+JASSJR_FUSION_SOURCE_ORDER: bm25,rm3,dense
+JASSJR_FUSION_SOURCE_BM25_PATH: /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse/pipeline-run.SP2rq0/results-bm25.trec
+JASSJR_FUSION_SOURCE_BM25_WEIGHT: 0.05
+JASSJR_FUSION_SOURCE_BM25_TOPK: 250
+JASSJR_FUSION_SOURCE_RM3_PATH: /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse/pipeline-run.SP2rq0/results-rm3.trec
+JASSJR_FUSION_SOURCE_RM3_WEIGHT: 0.55
+JASSJR_FUSION_SOURCE_RM3_TOPK: 250
+JASSJR_FUSION_SOURCE_DENSE_PATH: /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse/pipeline-run.SP2rq0/results-dense.trec
+JASSJR_FUSION_SOURCE_DENSE_WEIGHT: 0.4
+JASSJR_FUSION_SOURCE_DENSE_TOPK: 250
+
+JASSJR_OPENAI_RERANK_MODE: mono
+JASSJR_OPENAI_KEY_SOURCE: dotenv
+JASSJR_OPENAI_MONO_MODEL: gpt-5-mini
+JASSJR_OPENAI_DUO_MODEL: gpt-5-mini
+JASSJR_OPENAI_PROMPT_VERSION: openai-rerank-v2
+JASSJR_OPENAI_MONO_DOCS: 85
+JASSJR_OPENAI_DUO_DOCS: 10
+JASSJR_OPENAI_DOC_WORDS: 220
+JASSJR_OPENAI_CACHE_DIR: /Users/caiau/school/autoresearch/.cache/openai-rerank
+JASSJR_OPENAI_CACHE_HITS: 4219
+JASSJR_OPENAI_CACHE_MISSES: 31
+JASSJR_OPENAI_MONO_CALLS: 31
+JASSJR_OPENAI_DUO_CALLS: 0
+JASSJR_OPENAI_EST_INPUT_TOKENS: 1018874
+JASSJR_OPENAI_EST_OUTPUT_TOKENS: 34000
+JASSJR_OPENAI_ACTUAL_INPUT_TOKENS: 1325923
+JASSJR_OPENAI_ACTUAL_OUTPUT_TOKENS: 114750
+JASSJR_OPENAI_EST_COST_USD: 0.322719
+JASSJR_OPENAI_ACTUAL_COST_USD: 0.560981
+
+
+runid                 	all	JASSjr
+num_q                 	all	50
+num_ret               	all	50000
+num_rel               	all	6228
+num_rel_ret           	all	4079
+map                   	all	0.2808
+gm_map                	all	0.1837
+Rprec                 	all	0.3227
+bpref                 	all	0.3536
+recip_rank            	all	0.8154
+iprec_at_recall_0.00  	all	0.8359
+iprec_at_recall_0.10  	all	0.5552
+iprec_at_recall_0.20  	all	0.4586
+iprec_at_recall_0.30  	all	0.3944
+iprec_at_recall_0.40  	all	0.3362
+iprec_at_recall_0.50  	all	0.2830
+iprec_at_recall_0.60  	all	0.2172
+iprec_at_recall_0.70  	all	0.1464
+iprec_at_recall_0.80  	all	0.0982
+iprec_at_recall_0.90  	all	0.0605
+iprec_at_recall_1.00  	all	0.0108
+P_5                   	all	0.6040
+P_10                  	all	0.5340
+P_15                  	all	0.5093
+P_20                  	all	0.4930
+P_30                  	all	0.4600
+P_100                 	all	0.3022
+P_200                 	all	0.2224
+P_500                 	all	0.1316
+P_1000                	all	0.0816

--- a/search/JASSjr_search.go
+++ b/search/JASSjr_search.go
@@ -31,6 +31,12 @@ const defaultFeedbackDocs = 5
 const defaultExpansionTerms = 6
 const defaultExpansionWeight = 0.45
 const defaultExpansionMaxQueryTerms = 6
+const sparseFeedbackDocsBonus = 3
+const sparseExpansionTermsBonus = 4
+const sparseExpansionWeightBonus = 0.10
+const partialFeedbackDocsBonus = 2
+const partialExpansionTermsBonus = 2
+const partialExpansionWeightBonus = 0.05
 const defaultRerankDocs = 25
 const defaultRerankPassageWindow = 16
 const defaultRerankPassageWeight = 0.20
@@ -421,12 +427,38 @@ func rerankTopPassages(index loadedIndex, forwardFile *os.File, forwardOffsets [
 	return rerankedDocs
 }
 
-func selectExpansionTerms(index loadedIndex, forwardFile *os.File, forwardOffsets []int64, rankedDocs []int, rsv []float64, originalTerms map[string]struct{}) []weightedQueryTerm {
-	if feedbackDocs == 0 || expansionTerms == 0 || expansionWeight == 0 {
+func adaptiveExpansionParameters(index loadedIndex, originalTerms map[string]struct{}) (int, int, float64) {
+	feedbackDocLimit := feedbackDocs
+	expansionTermLimit := expansionTerms
+	expansionTermWeight := expansionWeight
+
+	indexedOriginalTerms := 0
+	for term := range originalTerms {
+		if _, ok := index.dictionary[term]; ok {
+			indexedOriginalTerms++
+		}
+	}
+
+	switch {
+	case len(originalTerms) <= 2 || indexedOriginalTerms <= 1:
+		feedbackDocLimit += sparseFeedbackDocsBonus
+		expansionTermLimit += sparseExpansionTermsBonus
+		expansionTermWeight = math.Min(expansionTermWeight+sparseExpansionWeightBonus, 0.75)
+	case indexedOriginalTerms < len(originalTerms):
+		feedbackDocLimit += partialFeedbackDocsBonus
+		expansionTermLimit += partialExpansionTermsBonus
+		expansionTermWeight = math.Min(expansionTermWeight+partialExpansionWeightBonus, 0.75)
+	}
+
+	return feedbackDocLimit, expansionTermLimit, expansionTermWeight
+}
+
+func selectExpansionTerms(index loadedIndex, forwardFile *os.File, forwardOffsets []int64, rankedDocs []int, rsv []float64, originalTerms map[string]struct{}, feedbackDocLimit int, expansionTermLimit int, expansionTermWeight float64) []weightedQueryTerm {
+	if feedbackDocLimit == 0 || expansionTermLimit == 0 || expansionTermWeight == 0 {
 		return nil
 	}
 
-	limit := feedbackDocs
+	limit := feedbackDocLimit
 	if len(rankedDocs) < limit {
 		limit = len(rankedDocs)
 	}
@@ -486,8 +518,8 @@ func selectExpansionTerms(index loadedIndex, forwardFile *os.File, forwardOffset
 		return cmp.Compare(a.token, b.token)
 	})
 
-	if len(selected) > expansionTerms {
-		selected = selected[:expansionTerms]
+	if len(selected) > expansionTermLimit {
+		selected = selected[:expansionTermLimit]
 	}
 
 	expansions := make([]weightedQueryTerm, 0, len(selected))
@@ -496,9 +528,9 @@ func selectExpansionTerms(index loadedIndex, forwardFile *os.File, forwardOffset
 		totalWeight += candidate.weight
 	}
 	for _, candidate := range selected {
-		weight := expansionWeight / float64(len(selected))
+		weight := expansionTermWeight / float64(len(selected))
 		if totalWeight > 0 {
-			weight = expansionWeight * candidate.weight / totalWeight
+			weight = expansionTermWeight * candidate.weight / totalWeight
 		}
 		expansions = append(expansions, weightedQueryTerm{token: candidate.token, weight: weight})
 	}
@@ -595,7 +627,8 @@ func main() {
 
 		touchedDocs = scoreQuery(index, queryTerms, rsv, touchedDocs)
 		if expansionMaxQueryTerms == 0 || len(queryTerms) <= expansionMaxQueryTerms {
-			expansions := selectExpansionTerms(index, forwardFile, forwardOffsets, touchedDocs, rsv, originalTerms)
+			feedbackDocLimit, expansionTermLimit, expansionTermWeight := adaptiveExpansionParameters(index, originalTerms)
+			expansions := selectExpansionTerms(index, forwardFile, forwardOffsets, touchedDocs, rsv, originalTerms, feedbackDocLimit, expansionTermLimit, expansionTermWeight)
 			if len(expansions) > 0 {
 				for _, expansion := range expansions {
 					accumulateScores(index, expansion.token, expansion.weight, rsv, &touchedDocs)


### PR DESCRIPTION
Closes #43.

## Hypothesis
Queries with weak lexical coverage should use a more aggressive RM3-style expansion plan than already-healthy title queries. Making the feedback budget adaptive by query sparsity should improve recall-oriented candidate generation without globally over-expanding every query.

## Change Summary
- add a sparse-query expansion plan in `search/JASSjr_search.go`
- keep the accepted global RM3 defaults for healthy queries
- widen feedback documents, expansion terms, and expansion weight only when the original title query is very short or only lightly represented in the lexical index

## Latest Metrics Vs Accepted Semantic Main Baseline
Accepted semantic baseline from `main` / #41:
- `map`: `0.2800`
- `Rprec`: `0.3217`
- `P_10`: `0.5340`
- `bpref`: `0.3528`
- `recip_rank`: `0.8154`
- `num_rel_ret`: `4072`

This branch (`experiment_evaluations/codex/search-adaptive-rm3-sparse/trec_eval-20260323-113344.txt`):
- `map`: `0.2808` (`+0.0008`)
- `Rprec`: `0.3227` (`+0.0010`)
- `P_10`: `0.5340` (`+0.0000`)
- `bpref`: `0.3536` (`+0.0008`)
- `recip_rank`: `0.8154` (`+0.0000`)
- `num_rel_ret`: `4079` (`+7`)
- `P_5`: `0.6040` vs `0.5960` (`+0.0080`)

## Validation
- `./tests/smoke.sh`
- `./tools/eval_wsj.sh /Users/caiau/school/wsj.xml`
- `JASSJR_SEMANTIC_MODE=openai JASSJR_OPENAI_RERANK_MODE=off ./tools/eval_wsj.sh -w /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse /Users/caiau/school/wsj.xml`
- `JASSJR_SEMANTIC_MODE=openai JASSJR_OPENAI_RERANK_MODE=mono ./tools/eval_wsj.sh -w /Users/caiau/school/autoresearch/wsj-eval/codex-search-adaptive-rm3-sparse /Users/caiau/school/wsj.xml`

## Branch-Vs-Main Comparison
`main` is the approval baseline. `original` remains a read-only historical initialization archive.

No `./tools/compare_branch_to_main.sh` summary is included here because this branch does not have a compatible benchmark artifact; benchmark runs remain optional under the current repo policy.

## Artifacts
- evaluation: `experiment_evaluations/codex/search-adaptive-rm3-sparse/trec_eval-20260323-113344.txt`
- benchmark: none produced for this branch

## Dashboard
- ran `./tools/update_metrics_dashboard.sh`
- the generated dashboard files remained effectively unchanged because the exporter skips branches without both evaluation and benchmark artifacts
- that limitation is carried forward here rather than fabricating benchmark data for a non-gating dimension
