### PR TITLE
Experiment: cap RM3 expansion candidates by document frequency

### DIFF
--- a/experiment_evaluations/codex/search-rm3-df-cap/trec_eval-20260327-115153.txt
+++ b/experiment_evaluations/codex/search-rm3-df-cap/trec_eval-20260327-115153.txt
@@ -1,0 +1,39 @@
+branch: codex/search-rm3-df-cap
+timestamp: 20260327-115153
+collection: /Users/caiau/school/wsj.xml
+topics: /Users/caiau/school/autoresearch/51-100.titles.txt
+qrels: /Users/caiau/school/autoresearch/51-100.qrels.txt
+
+JASSJR_OPENAI_RERANK_MODE: off
+JASSJR_OPENAI_KEY_SOURCE: dotenv
+
+runid                 	all	JASSjr
+num_q                 	all	50
+num_ret               	all	50000
+num_rel               	all	6228
+num_rel_ret           	all	3904
+map                   	all	0.2540
+gm_map                	all	0.1249
+Rprec                 	all	0.2989
+bpref                 	all	0.3190
+recip_rank            	all	0.6524
+iprec_at_recall_0.00  	all	0.6948
+iprec_at_recall_0.10  	all	0.4900
+iprec_at_recall_0.20  	all	0.4213
+iprec_at_recall_0.30  	all	0.3532
+iprec_at_recall_0.40  	all	0.3093
+iprec_at_recall_0.50  	all	0.2601
+iprec_at_recall_0.60  	all	0.2130
+iprec_at_recall_0.70  	all	0.1522
+iprec_at_recall_0.80  	all	0.0991
+iprec_at_recall_0.90  	all	0.0561
+iprec_at_recall_1.00  	all	0.0107
+P_5                   	all	0.4840
+P_10                  	all	0.4440
+P_15                  	all	0.4240
+P_20                  	all	0.4100
+P_30                  	all	0.3840
+P_100                 	all	0.2854
+P_200                 	all	0.2148
+P_500                 	all	0.1300
+P_1000                	all	0.0781

--- a/search/JASSjr_search.go
+++ b/search/JASSjr_search.go
@@ -31,6 +31,7 @@ const defaultFeedbackDocs = 5
 const defaultExpansionTerms = 6
 const defaultExpansionWeight = 0.45
 const defaultExpansionMaxQueryTerms = 6
+const defaultExpansionMaxDocFreqFraction = 0.10
 const defaultRerankDocs = 25
 const defaultRerankPassageWindow = 16
 const defaultRerankPassageWeight = 0.20
@@ -465,6 +466,10 @@ func selectExpansionTerms(index loadedIndex, forwardFile *os.File, forwardOffset
 			}
 			postings := int(termDetails.size / 8)
 			if postings == 0 || postings == index.documentsInCollection {
+				continue
+			}
+			if float64(postings)/float64(index.documentsInCollection) > defaultExpansionMaxDocFreqFraction {
+				// Keep extremely common collection-wide terms out of RM3 feedback.
 				continue
 			}
 


### PR DESCRIPTION
Closes #56.

## Hypothesis
The accepted RM3 recall baseline on `main` still allows very common pseudo-relevance feedback terms into the expanded query. Filtering out extremely common collection-wide terms only from the expansion candidate set should preserve recall while recovering a bit of precision for WSJ title queries.

## Change Summary
- add a conservative document-frequency ceiling for RM3 expansion candidates in `search/JASSjr_search.go`
- leave original query scoring, passage reranking, and the rest of the lexical pipeline unchanged

## Latest Metrics Vs Main Approval Baseline
Refreshed `main` baseline from `experiment_evaluations/main/trec_eval-20260327-114802.txt`:
- `map`: `0.2530`
- `Rprec`: `0.2989`
- `P_10`: `0.4440`
- `bpref`: `0.3182`
- `recip_rank`: `0.6523`
- `num_rel_ret`: `3904`

This branch (`experiment_evaluations/codex/search-rm3-df-cap/trec_eval-20260327-115153.txt`):
- `map`: `0.2540` (`+0.0010`)
- `Rprec`: `0.2989` (`+0.0000`)
- `P_10`: `0.4440` (`+0.0000`)
- `bpref`: `0.3190` (`+0.0008`)
- `recip_rank`: `0.6524` (`+0.0001`)
- `num_rel_ret`: `3904` (`+0`)
- `P_20`: `0.4100` vs `0.4060` (`+0.0040`)

## Validation
- `./tests/smoke.sh`
- `./tools/eval_wsj.sh /Users/caiau/school/wsj.xml`

## Branch-Vs-Main Comparison
`main` is the approval baseline. `original` remains a read-only historical initialization archive.

No `./tools/compare_branch_to_main.sh` summary is included here because this branch does not have a compatible benchmark artifact; benchmark runs remain optional under the current repo policy.

## Artifacts
- evaluation: `experiment_evaluations/codex/search-rm3-df-cap/trec_eval-20260327-115153.txt`
- benchmark: none produced for this branch

## Dashboard
- ran `./tools/update_metrics_dashboard.sh`
- the generated dashboard files did not change because the exporter currently skips branches without both evaluation and benchmark artifacts
